### PR TITLE
Fix potential vulnerability in cloned code

### DIFF
--- a/SDK/rv1106-sdk/sysdrv/source/kernel/drivers/net/wireless/microchip/wilc1000/cfg80211.c
+++ b/SDK/rv1106-sdk/sysdrv/source/kernel/drivers/net/wireless/microchip/wilc1000/cfg80211.c
@@ -940,7 +940,8 @@ static inline void wilc_wfi_cfg_parse_ch_attr(u8 *buf, u32 len, u8 sta_ch)
 
 	while (index + sizeof(*e) <= len) {
 		e = (struct wilc_attr_entry *)&buf[index];
-		if (e->attr_type == IEEE80211_P2P_ATTR_CHANNEL_LIST)
+		if (e->attr_type == IEEE80211_P2P_ATTR_CHANNEL_LIST &&
+		    attr_size >= (sizeof(struct wilc_attr_ch_list) - sizeof(*e)))
 			ch_list_idx = index;
 		else if (e->attr_type == IEEE80211_P2P_ATTR_OPER_CHANNEL)
 			op_ch_idx = index;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `wilc_wfi_cfg_parse_ch_attr` that was cloned from `torvalds/linux` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `wilc_wfi_cfg_parse_ch_attr` in `SDK/rv1106-sdk/sysdrv/source/kernel/drivers/net/wireless/microchip/wilc1000/cfg80211.c`
* **Original Fix**: https://github.com/torvalds/linux/commit/f9b62f9843c7b0afdaecabbcebf1dbba18599408

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/torvalds/linux/commit/f9b62f9843c7b0afdaecabbcebf1dbba18599408
* [CVE-2022-47521](https://nvd.nist.gov/vuln/detail/CVE-2022-47521)

Please review and merge this PR to ensure your repository is protected against this vulnerability.